### PR TITLE
Add delivery cashout tracking

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,11 +6,14 @@
         android:label="@string/app_name"
         android:theme="@style/Theme.CorteCaja">
         <activity
+            android:name=".HistoryActivity"
+            android:exported="false" />
+        <activity
             android:name=".MainActivity"
             android:exported="true">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/java/com/example/corte/HistoryActivity.kt
+++ b/app/src/main/java/com/example/corte/HistoryActivity.kt
@@ -1,40 +1,42 @@
 package com.example.corte
 
 import android.os.Bundle
-import android.widget.ArrayAdapter
 import androidx.appcompat.app.AppCompatActivity
 import com.example.corte.databinding.ActivityHistoryBinding
 import com.example.corte.data.AppDatabase
-import com.example.corte.data.DeliveryEntry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 class HistoryActivity : AppCompatActivity() {
-  private lateinit var binding: ActivityHistoryBinding
-  private val db by lazy { AppDatabase.getInstance(this) }
+    private lateinit var binding: ActivityHistoryBinding
+    private val db by lazy { AppDatabase.getInstance(this) }
 
-  override fun onCreate(savedInstanceState: Bundle?) {
-    super.onCreate(savedInstanceState)
-    binding = ActivityHistoryBinding.inflate(layoutInflater)
-    setContentView(binding.root)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityHistoryBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-    // Por defecto, muestro últimas 24h:
-    val now = System.currentTimeMillis()
-    val oneDayAgo = now - 24 * 60 * 60 * 1000
+        CoroutineScope(Dispatchers.IO).launch {
+            val orders = db.orderDao().getAll()
+            val withdrawals = db.withdrawalDao().getAll()
 
-    CoroutineScope(Dispatchers.IO).launch {
-      val entries: List<DeliveryEntry> = db.deliveryDao().getEntriesInRange(oneDayAgo, now)
-      val displayList: List<String> = entries.map { "${it.amount} @ ${java.text.DateFormat.getDateTimeInstance().format(it.timestamp)}" }
-      withContext(Dispatchers.Main) {
-        if (displayList.isEmpty()) {
-          binding.tvEmpty.visibility = android.view.View.VISIBLE
-        } else {
-          binding.tvEmpty.visibility = android.view.View.GONE
-          binding.listView.adapter = ArrayAdapter(this@HistoryActivity, android.R.layout.simple_list_item_1, displayList)
+            val totalOrders = orders.size
+            val totalCash = orders.filter { it.paymentType == "CASH" }.sumOf { it.amount }
+            val totalCard = orders.filter { it.paymentType == "CARD" }.sumOf { it.amount }
+            val totalTips = orders.sumOf { it.tip }
+            val totalWithdrawals = withdrawals.sumOf { it.amount }
+            val netCash = totalCash - totalWithdrawals
+
+            withContext(Dispatchers.Main) {
+                binding.tvOrders.text = getString(R.string.format_orders, totalOrders)
+                binding.tvCash.text = getString(R.string.format_cash, totalCash)
+                binding.tvCard.text = getString(R.string.format_card, totalCard)
+                binding.tvTips.text = getString(R.string.format_tips, totalTips)
+                binding.tvWithdrawals.text = getString(R.string.format_withdrawals, totalWithdrawals)
+                binding.tvNetCash.text = getString(R.string.format_net_cash, netCash)
+            }
         }
-      }
     }
-  }
 }

--- a/app/src/main/java/com/example/corte/MainActivity.kt
+++ b/app/src/main/java/com/example/corte/MainActivity.kt
@@ -5,30 +5,46 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import com.example.corte.databinding.ActivityMainBinding
 import com.example.corte.data.AppDatabase
-import com.example.corte.data.DeliveryEntry
+import com.example.corte.data.OrderEntry
+import com.example.corte.data.WithdrawalEntry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class MainActivity : AppCompatActivity() {
-  private lateinit var binding: ActivityMainBinding
-  private val db by lazy { AppDatabase.getInstance(this) }
+    private lateinit var binding: ActivityMainBinding
+    private val db by lazy { AppDatabase.getInstance(this) }
 
-  override fun onCreate(savedInstanceState: Bundle?) {
-    super.onCreate(savedInstanceState)
-    binding = ActivityMainBinding.inflate(layoutInflater)
-    setContentView(binding.root)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-    binding.btnSave.setOnClickListener {
-      val amount = binding.etAmount.text.toString().toDoubleOrNull() ?: return@setOnClickListener
-      val now = System.currentTimeMillis()
-      CoroutineScope(Dispatchers.IO).launch {
-        db.deliveryDao().insert(DeliveryEntry(amount = amount, timestamp = now))
-      }
+        binding.btnSave.setOnClickListener {
+            val amount = binding.etAmount.text.toString().toDoubleOrNull() ?: return@setOnClickListener
+            val paymentType = if (binding.rbCash.isChecked) "CASH" else "CARD"
+            val tip = if (paymentType == "CARD") binding.etTip.text.toString().toDoubleOrNull() ?: 0.0 else 0.0
+            val now = System.currentTimeMillis()
+            CoroutineScope(Dispatchers.IO).launch {
+                db.orderDao().insert(
+                    OrderEntry(amount = amount, paymentType = paymentType, tip = tip, timestamp = now)
+                )
+            }
+            binding.etAmount.text.clear()
+            binding.etTip.text.clear()
+        }
+
+        binding.btnWithdraw.setOnClickListener {
+            val amount = binding.etWithdrawal.text.toString().toDoubleOrNull() ?: return@setOnClickListener
+            val now = System.currentTimeMillis()
+            CoroutineScope(Dispatchers.IO).launch {
+                db.withdrawalDao().insert(WithdrawalEntry(amount = amount, timestamp = now))
+            }
+            binding.etWithdrawal.text.clear()
+        }
+
+        binding.btnHistory.setOnClickListener {
+            startActivity(Intent(this, HistoryActivity::class.java))
+        }
     }
-
-    binding.btnHistory.setOnClickListener {
-      startActivity(Intent(this, HistoryActivity::class.java))
-    }
-  }
 }

--- a/app/src/main/java/com/example/corte/data/AppDatabase.kt
+++ b/app/src/main/java/com/example/corte/data/AppDatabase.kt
@@ -5,19 +5,25 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 
-@Database(entities = [DeliveryEntry::class], version = 1, exportSchema = false)
+@Database(
+    entities = [OrderEntry::class, WithdrawalEntry::class],
+    version = 2,
+    exportSchema = false
+)
 abstract class AppDatabase : RoomDatabase() {
-  abstract fun deliveryDao(): DeliveryDao
+    abstract fun orderDao(): OrderDao
+    abstract fun withdrawalDao(): WithdrawalDao
 
-  companion object {
-    @Volatile private var INSTANCE: AppDatabase? = null
+    companion object {
+        @Volatile private var INSTANCE: AppDatabase? = null
 
-    fun getInstance(context: Context): AppDatabase =
-      INSTANCE ?: synchronized(this) {
-        INSTANCE ?: Room
-          .databaseBuilder(context, AppDatabase::class.java, "delivery-db")
-          .build()
-          .also { INSTANCE = it }
-      }
-  }
+        fun getInstance(context: Context): AppDatabase =
+            INSTANCE ?: synchronized(this) {
+                INSTANCE ?: Room
+                    .databaseBuilder(context, AppDatabase::class.java, "delivery-db")
+                    .fallbackToDestructiveMigration()
+                    .build()
+                    .also { INSTANCE = it }
+            }
+    }
 }

--- a/app/src/main/java/com/example/corte/data/OrderDao.kt
+++ b/app/src/main/java/com/example/corte/data/OrderDao.kt
@@ -1,0 +1,14 @@
+package com.example.corte.data
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+
+@Dao
+interface OrderDao {
+    @Insert
+    suspend fun insert(order: OrderEntry)
+
+    @Query("SELECT * FROM orders")
+    suspend fun getAll(): List<OrderEntry>
+}

--- a/app/src/main/java/com/example/corte/data/OrderEntry.kt
+++ b/app/src/main/java/com/example/corte/data/OrderEntry.kt
@@ -1,0 +1,13 @@
+package com.example.corte.data
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "orders")
+data class OrderEntry(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val amount: Double,
+    val paymentType: String,
+    val tip: Double = 0.0,
+    val timestamp: Long
+)

--- a/app/src/main/java/com/example/corte/data/WithdrawalDao.kt
+++ b/app/src/main/java/com/example/corte/data/WithdrawalDao.kt
@@ -1,0 +1,14 @@
+package com.example.corte.data
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+
+@Dao
+interface WithdrawalDao {
+    @Insert
+    suspend fun insert(withdrawal: WithdrawalEntry)
+
+    @Query("SELECT * FROM withdrawals")
+    suspend fun getAll(): List<WithdrawalEntry>
+}

--- a/app/src/main/java/com/example/corte/data/WithdrawalEntry.kt
+++ b/app/src/main/java/com/example/corte/data/WithdrawalEntry.kt
@@ -1,0 +1,11 @@
+package com.example.corte.data
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "withdrawals")
+data class WithdrawalEntry(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val amount: Double,
+    val timestamp: Long
+)

--- a/app/src/main/res/layout/activity_history.xml
+++ b/app/src/main/res/layout/activity_history.xml
@@ -1,17 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical" android:padding="16dp"
-    android:layout_width="match_parent" android:layout_height="match_parent">
+    android:orientation="vertical"
+    android:padding="16dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
     <TextView
-        android:id="@+id/tvEmpty"
-        android:text="@string/msg_no_data"
-        android:visibility="gone"
+        android:text="@string/title_history"
+        android:textStyle="bold"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content" />
 
-    <ListView
-        android:id="@+id/listView"
+    <TextView
+        android:id="@+id/tvOrders"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="wrap_content" />
+    <TextView
+        android:id="@+id/tvCash"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+    <TextView
+        android:id="@+id/tvCard"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+    <TextView
+        android:id="@+id/tvTips"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+    <TextView
+        android:id="@+id/tvWithdrawals"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+    <TextView
+        android:id="@+id/tvNetCash"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
 </LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,25 +1,73 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical" android:padding="16dp"
-    android:layout_width="match_parent" android:layout_height="match_parent">
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
-    <EditText
-        android:id="@+id/etAmount"
-        android:hint="@string/hint_monto"
-        android:inputType="numberDecimal"
+    <LinearLayout
+        android:orientation="vertical"
+        android:padding="16dp"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content">
 
-    <Button
-        android:id="@+id/btnSave"
-        android:text="@string/button_guardar"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
+        <EditText
+            android:id="@+id/etAmount"
+            android:hint="@string/hint_monto"
+            android:inputType="numberDecimal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
 
-    <Button
-        android:id="@+id/btnHistory"
-        android:text="@string/button_historial"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
+        <RadioGroup
+            android:id="@+id/rgPayment"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+            <RadioButton
+                android:id="@+id/rbCash"
+                android:text="@string/label_cash"
+                android:checked="true"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+            <RadioButton
+                android:id="@+id/rbCard"
+                android:text="@string/label_card"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+        </RadioGroup>
 
-</LinearLayout>
+        <EditText
+            android:id="@+id/etTip"
+            android:hint="@string/hint_tip"
+            android:inputType="numberDecimal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <Button
+            android:id="@+id/btnSave"
+            android:text="@string/button_guardar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="16dp" />
+
+        <EditText
+            android:id="@+id/etWithdrawal"
+            android:hint="@string/hint_withdrawal"
+            android:inputType="numberDecimal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <Button
+            android:id="@+id/btnWithdraw"
+            android:text="@string/button_withdraw"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <Button
+            android:id="@+id/btnHistory"
+            android:text="@string/button_historial"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,27 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Nombre y metadatos de la app -->
     <string name="app_name">RepartidorCaja</string>
     <string name="launcher_name">RepartidorCaja</string>
 
-    <!-- Etiquetas de botones y campos -->
-    <string name="hint_monto">Monto de la entrega</string>
-    <string name="button_guardar">Registrar entrega</string>
-    <string name="button_historial">Ver entregas</string>
+    <string name="hint_monto">Monto del pedido</string>
+    <string name="hint_tip">Propina en tarjeta</string>
+    <string name="hint_withdrawal">Retiro en efectivo</string>
+    <string name="button_guardar">Registrar pedido</string>
+    <string name="button_historial">Corte de caja</string>
+    <string name="button_withdraw">Registrar retiro</string>
+    <string name="label_cash">Efectivo</string>
+    <string name="label_card">Tarjeta</string>
 
-    <!-- Títulos de pantallas -->
-    <string name="title_main">Registro de Entregas</string>
-    <string name="title_history">Historial de Entregas</string>
+    <string name="title_main">Registro de Pedidos</string>
+    <string name="title_history">Corte de Caja</string>
 
-    <!-- Columnas del historial -->
-    <string name="column_fecha">Fecha</string>
-    <string name="column_monto">Monto</string>
+    <string name="format_orders">Pedidos: %1$d</string>
+    <string name="format_cash">Efectivo: %1$.2f</string>
+    <string name="format_card">Tarjeta: %1$.2f</string>
+    <string name="format_tips">Propinas: %1$.2f</string>
+    <string name="format_withdrawals">Retiros: %1$.2f</string>
+    <string name="format_net_cash">Total en caja: %1$.2f</string>
 
-    <!-- Mensajes de estado -->
-    <string name="msg_no_data">No hay entregas registradas</string>
-    <string name="msg_error">Ocurrió un error, inténtalo de nuevo</string>
-    <string name="msg_calculando">Calculando…</string>
-
-    <!-- Permisos y otros textos -->
-    <string name="permission_storage">Necesitamos acceso al almacenamiento para guardar el historial</string>
+    <string name="msg_no_data">Sin datos</string>
 </resources>


### PR DESCRIPTION
## Summary
- add OrderEntry and WithdrawalEntry entities for orders and cash withdrawals
- add corresponding DAOs and update AppDatabase
- track orders, withdrawals and tips in MainActivity
- compute summary in HistoryActivity
- update layouts and strings for new fields
- add HistoryActivity to the manifest

## Testing
- `gradle assembleDebug --no-daemon` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68634ba31d3c832392575b8dcc588a53